### PR TITLE
feat: バックエンド・フロントエンドの .env.example と .gitignore を追加

### DIFF
--- a/nippou/backend/.env.example
+++ b/nippou/backend/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/nippou
+DATABASE_URL_TEST=postgresql://user:password@localhost:5432/nippou_test
+JWT_SECRET=your-secret-key
+PORT=3001

--- a/nippou/backend/.gitignore
+++ b/nippou/backend/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+coverage/

--- a/nippou/frontend/.env.example
+++ b/nippou/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001/v1

--- a/nippou/frontend/.gitignore
+++ b/nippou/frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+.env
+coverage/


### PR DESCRIPTION
## 概要

Issue #2 の実装。フロント・バックエンド双方の環境変数テンプレートと `.gitignore` を追加する。

## 変更内容

- `backend/.env.example` — `DATABASE_URL` / `DATABASE_URL_TEST` / `JWT_SECRET` / `PORT`
- `frontend/.env.example` — `NEXT_PUBLIC_API_URL`
- `backend/.gitignore` — `node_modules/`, `dist/`, `.env`, `coverage/`
- `frontend/.gitignore` — `node_modules/`, `.next/`, `.env`, `coverage/`

## セットアップ手順

```bash
# バックエンド
cp backend/.env.example backend/.env
# .env の各値を環境に合わせて書き換える

# フロントエンド
cp frontend/.env.example frontend/.env.local
```

## 完了条件チェック

- [x] `backend/.env.example` が作成されている
- [x] `frontend/.env.example` が作成されている
- [x] `.gitignore` に `.env` が追加されている

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)