### PR TITLE
feat: Express ミドルウェア基盤設定（CORS・JWT認証・エラーハンドリング）

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,12 +10,16 @@
       "dependencies": {
         "@prisma/client": "^6.6.0",
         "bcrypt": "^5.1.1",
-        "express": "^4.21.2"
+        "cors": "^2.8.5",
+        "express": "^4.21.2",
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
+        "@types/cors": "^2.8.17",
         "@types/express": "^5",
         "@types/jest": "^30.0.0",
+        "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^20",
         "@types/supertest": "^7.2.0",
         "@typescript-eslint/eslint-plugin": "^8",
@@ -2188,6 +2192,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2272,10 +2286,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
       "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3336,6 +3368,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3763,6 +3801,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -3966,6 +4021,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6309,6 +6373,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6366,6 +6473,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6378,6 +6521,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,11 +27,15 @@
   "dependencies": {
     "@prisma/client": "^6.6.0",
     "bcrypt": "^5.1.1",
-    "express": "^4.21.2"
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
+    "@types/cors": "^2.8.17",
     "@types/express": "^5",
+    "@types/jsonwebtoken": "^9.0.9",
     "prisma": "^6.6.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",

--- a/backend/src/__tests__/middlewares/auth.test.ts
+++ b/backend/src/__tests__/middlewares/auth.test.ts
@@ -1,0 +1,55 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { authenticate } from "../../middlewares/auth";
+import { errorHandler } from "../../middlewares/errorHandler";
+
+const SECRET = "test-secret";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.get("/protected", authenticate, (req, res) => {
+    res.json({ user: req.user });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe("authenticate middleware", () => {
+  const originalEnv = process.env.JWT_SECRET;
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    process.env.JWT_SECRET = originalEnv;
+  });
+
+  it("passes with valid token", async () => {
+    const token = jwt.sign({ user_id: 1, role: "sales" }, SECRET);
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({ user_id: 1, role: "sales" });
+  });
+
+  it("returns 401 without Authorization header", async () => {
+    const res = await request(buildApp()).get("/protected");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 with invalid token", async () => {
+    const res = await request(buildApp())
+      .get("/protected")
+      .set("Authorization", "Bearer invalid.token.here");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/backend/src/__tests__/middlewares/errorHandler.test.ts
+++ b/backend/src/__tests__/middlewares/errorHandler.test.ts
@@ -1,0 +1,53 @@
+import request from "supertest";
+import express, { Request, Response, NextFunction } from "express";
+import { AppError, errorHandler } from "../../middlewares/errorHandler";
+
+function buildApp(handler: (req: Request, res: Response, next: NextFunction) => void) {
+  const app = express();
+  app.get("/test", handler);
+  app.use(errorHandler);
+  return app;
+}
+
+describe("errorHandler middleware", () => {
+  it("handles AppError with correct status and body", async () => {
+    const app = buildApp((_req, _res, next) => {
+      next(new AppError(400, "VALIDATION_ERROR", "入力値が不正です", [
+        { field: "email", message: "メール形式で入力してください" },
+      ]));
+    });
+
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "入力値が不正です",
+        details: [{ field: "email", message: "メール形式で入力してください" }],
+      },
+    });
+  });
+
+  it("handles unknown errors as 500", async () => {
+    const app = buildApp((_req, _res, next) => {
+      next(new Error("unexpected error"));
+    });
+
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  it("handles AppError without details", async () => {
+    const app = buildApp((_req, _res, next) => {
+      next(new AppError(404, "NOT_FOUND", "リソースが見つかりません"));
+    });
+
+    const res = await request(app).get("/test");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).not.toHaveProperty("details");
+  });
+});

--- a/backend/src/__tests__/middlewares/role.test.ts
+++ b/backend/src/__tests__/middlewares/role.test.ts
@@ -1,0 +1,48 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { authenticate } from "../../middlewares/auth";
+import { requireRole } from "../../middlewares/role";
+import { errorHandler } from "../../middlewares/errorHandler";
+
+const SECRET = "test-secret";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.get(
+    "/manager-only",
+    authenticate,
+    requireRole("manager"),
+    (_req, res) => {
+      res.json({ ok: true });
+    }
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("requireRole middleware", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = SECRET;
+  });
+
+  it("allows manager role", async () => {
+    const token = jwt.sign({ user_id: 3, role: "manager" }, SECRET);
+    const res = await request(buildApp())
+      .get("/manager-only")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 for sales role", async () => {
+    const token = jwt.sign({ user_id: 1, role: "sales" }, SECRET);
+    const res = await request(buildApp())
+      .get("/manager-only")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,20 @@
 import express from "express";
+import cors from "cors";
+import { errorHandler } from "./middlewares/errorHandler";
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;
+
+const allowedOrigins = process.env.FRONTEND_URL
+  ? [process.env.FRONTEND_URL]
+  : ["http://localhost:3000"];
+
+app.use(
+  cors({
+    origin: allowedOrigins,
+    credentials: true,
+  })
+);
 
 app.use(express.json());
 
@@ -9,6 +22,10 @@ app.get("/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
+app.use(errorHandler);
+
 app.listen(PORT, () => {
   console.warn(`Server running on port ${PORT}`);
 });
+
+export { app };

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -1,0 +1,45 @@
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { AppError } from "./errorHandler";
+
+export interface JwtPayload {
+  user_id: number;
+  role: "sales" | "manager";
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: JwtPayload;
+    }
+  }
+}
+
+export function authenticate(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    return next(
+      new AppError(401, "UNAUTHORIZED", "認証トークンが必要です")
+    );
+  }
+
+  const token = authHeader.slice(7);
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    return next(
+      new AppError(500, "INTERNAL_SERVER_ERROR", "サーバーエラーが発生しました")
+    );
+  }
+
+  try {
+    const payload = jwt.verify(token, secret) as JwtPayload;
+    req.user = payload;
+    next();
+  } catch {
+    next(new AppError(401, "UNAUTHORIZED", "トークンが無効または期限切れです"));
+  }
+}

--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from "express";
+
+export type ErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "INTERNAL_SERVER_ERROR";
+
+export class AppError extends Error {
+  constructor(
+    public statusCode: number,
+    public code: ErrorCode,
+    public message: string,
+    public details?: { field: string; message: string }[]
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+export function errorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  if (err instanceof AppError) {
+    res.status(err.statusCode).json({
+      error: {
+        code: err.code,
+        message: err.message,
+        ...(err.details ? { details: err.details } : {}),
+      },
+    });
+    return;
+  }
+
+  console.error(err);
+  res.status(500).json({
+    error: {
+      code: "INTERNAL_SERVER_ERROR",
+      message: "サーバーエラーが発生しました",
+    },
+  });
+}

--- a/backend/src/middlewares/role.ts
+++ b/backend/src/middlewares/role.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+import { JwtPayload } from "./auth";
+import { AppError } from "./errorHandler";
+
+export function requireRole(...roles: JwtPayload["role"][]) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    if (!req.user) {
+      return next(new AppError(401, "UNAUTHORIZED", "認証が必要です"));
+    }
+    if (!roles.includes(req.user.role)) {
+      return next(new AppError(403, "FORBIDDEN", "権限がありません"));
+    }
+    next();
+  };
+}


### PR DESCRIPTION
## Summary

- `cors` パッケージで CORS 設定（`FRONTEND_URL` 環境変数で許可オリジンを制御）
- `authenticate` ミドルウェア: `Authorization: Bearer {token}` を検証し `req.user` にペイロードをセット
- `requireRole(...roles)` ミドルウェア: `sales` / `manager` ロール別アクセス制御
- `AppError` クラスと `errorHandler`: API仕様書準拠の共通エラーレスポンス形式

## Test plan

- [x] `npm test` — 9テスト全通過（auth / role / errorHandler ミドルウェア）
- [x] `npm run type-check` — 型エラーなし

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)