### PR TITLE
feat: GET・POST /daily-reports 実装

### DIFF
--- a/backend/src/__tests__/routes/dailyReports.test.ts
+++ b/backend/src/__tests__/routes/dailyReports.test.ts
@@ -1,0 +1,451 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { errorHandler } from "../../middlewares/errorHandler";
+import dailyReportsRouter from "../../routes/dailyReports";
+
+const SECRET = "test-secret";
+
+// Prisma Client のモック（jest.mock はホイストされるため内部で jest.fn() を定義）
+jest.mock("@prisma/client", () => {
+  const mocks = {
+    dailyReport: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn(),
+    },
+    customer: {
+      findMany: jest.fn(),
+    },
+  };
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => mocks),
+    __mocks: mocks,
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { __mocks } = require("@prisma/client");
+
+const mockDailyReportFindMany: jest.Mock = __mocks.dailyReport.findMany;
+const mockDailyReportCount: jest.Mock = __mocks.dailyReport.count;
+const mockDailyReportCreate: jest.Mock = __mocks.dailyReport.create;
+const mockCustomerFindMany: jest.Mock = __mocks.customer.findMany;
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1/daily-reports", dailyReportsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+function makeToken(userId: number, role: "sales" | "manager"): string {
+  return jwt.sign({ user_id: userId, role }, SECRET, { expiresIn: "24h" });
+}
+
+const salesToken = makeToken(1, "sales");
+const managerToken = makeToken(3, "manager");
+
+const now = new Date("2026-04-18T09:00:00Z");
+
+const makeReport = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  reportId: 1,
+  userId: 1,
+  reportDate: new Date("2026-04-18"),
+  problem: null,
+  plan: null,
+  status: "draft",
+  createdAt: now,
+  updatedAt: now,
+  user: { userId: 1, name: "山田 太郎" },
+  visitRecords: [],
+  comments: [],
+  ...overrides,
+});
+
+describe("GET /v1/daily-reports", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // AT-DR-001 #8: 未認証
+  it("未認証でアクセス: 401 UNAUTHORIZED", async () => {
+    const res = await request(buildApp()).get("/v1/daily-reports");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  // AT-DR-001 #1: 自分の日報一覧取得
+  it("sales が自分の日報一覧取得: 自分の日報のみ返る (200)", async () => {
+    const reports = [makeReport(), makeReport({ reportId: 2, reportDate: new Date("2026-04-17") })];
+    mockDailyReportCount.mockResolvedValue(2);
+    mockDailyReportFindMany.mockResolvedValue(reports);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toHaveLength(2);
+    expect(res.body.data.pagination.total).toBe(2);
+
+    const { where } = mockDailyReportFindMany.mock.calls[0][0];
+    expect(where.userId).toBe(1);
+  });
+
+  // AT-DR-001 #2: sales が user_id=2 を指定しても自分の日報のみ
+  it("sales が user_id=2 指定: user_id は無視され自分の日報のみ (200)", async () => {
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue([makeReport()]);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports?user_id=2")
+      .set("Authorization", `Bearer ${salesToken}`);
+
+    expect(res.status).toBe(200);
+    const { where } = mockDailyReportFindMany.mock.calls[0][0];
+    expect(where.userId).toBe(1);
+  });
+
+  // AT-DR-001 #3: manager が全ユーザーの日報取得
+  it("manager が全ユーザーの日報取得: 全ユーザーの日報が返る (200)", async () => {
+    const reports = [
+      makeReport(),
+      makeReport({ reportId: 2, userId: 2, user: { userId: 2, name: "佐藤 花子" } }),
+    ];
+    mockDailyReportCount.mockResolvedValue(2);
+    mockDailyReportFindMany.mockResolvedValue(reports);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports")
+      .set("Authorization", `Bearer ${managerToken}`);
+
+    expect(res.status).toBe(200);
+    const { where } = mockDailyReportFindMany.mock.calls[0][0];
+    expect(where.userId).toBeUndefined();
+  });
+
+  // AT-DR-001 #4: manager が user_id=1 で絞り込み
+  it("manager が user_id=1 で絞り込み: 山田の日報のみ返る (200)", async () => {
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue([makeReport()]);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports?user_id=1")
+      .set("Authorization", `Bearer ${managerToken}`);
+
+    expect(res.status).toBe(200);
+    const { where } = mockDailyReportFindMany.mock.calls[0][0];
+    expect(where.userId).toBe(1);
+  });
+
+  // AT-DR-001 #5: status で絞り込み
+  it("status=draft で絞り込み: 下書きのみ返る (200)", async () => {
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue([makeReport()]);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports?status=draft")
+      .set("Authorization", `Bearer ${salesToken}`);
+
+    expect(res.status).toBe(200);
+    const { where } = mockDailyReportFindMany.mock.calls[0][0];
+    expect(where.status).toBe("draft");
+  });
+
+  // AT-DR-001 #6: 期間で絞り込み
+  it("date_from・date_to で絞り込み: 指定期間内の日報のみ返る (200)", async () => {
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue([makeReport()]);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports?date_from=2026-04-01&date_to=2026-04-10")
+      .set("Authorization", `Bearer ${salesToken}`);
+
+    expect(res.status).toBe(200);
+    const { where } = mockDailyReportFindMany.mock.calls[0][0];
+    expect(where.reportDate?.gte).toEqual(new Date("2026-04-01"));
+    expect(where.reportDate?.lte).toEqual(new Date("2026-04-10"));
+  });
+
+  // AT-DR-001 #7: ページネーション
+  it("ページネーション: page=2, per_page=20, total=25 → 5件返る (200)", async () => {
+    const fiveReports = Array.from({ length: 5 }, (_, i) =>
+      makeReport({ reportId: i + 21, reportDate: new Date(`2026-04-${i + 1}`) })
+    );
+    mockDailyReportCount.mockResolvedValue(25);
+    mockDailyReportFindMany.mockResolvedValue(fiveReports);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports?page=2&per_page=20")
+      .set("Authorization", `Bearer ${salesToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toHaveLength(5);
+    expect(res.body.data.pagination.total).toBe(25);
+    expect(res.body.data.pagination.total_pages).toBe(2);
+    expect(res.body.data.pagination.page).toBe(2);
+
+    const { skip, take } = mockDailyReportFindMany.mock.calls[0][0];
+    expect(skip).toBe(20);
+    expect(take).toBe(20);
+  });
+
+  it("レスポンスフィールドを確認: report_id・user・status・visit_count など", async () => {
+    const report = makeReport({
+      visitRecords: [{ visitId: 1 }, { visitId: 2 }],
+      status: "submitted",
+    });
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue([report]);
+
+    const res = await request(buildApp())
+      .get("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`);
+
+    expect(res.status).toBe(200);
+    const item = res.body.data.items[0];
+    expect(item.report_id).toBe(1);
+    expect(item.user).toEqual({ user_id: 1, name: "山田 太郎" });
+    expect(item.report_date).toBe("2026-04-18");
+    expect(item.status).toBe("submitted");
+    expect(item.visit_count).toBe(2);
+    expect(item.created_at).toBeDefined();
+    expect(item.updated_at).toBeDefined();
+  });
+});
+
+describe("POST /v1/daily-reports", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // AT-DR-002 #5: manager が作成 → 403
+  it("manager が作成: 403 FORBIDDEN", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${managerToken}`)
+      .send({ report_date: "2026-04-18" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  // 未認証
+  it("未認証でアクセス: 401 UNAUTHORIZED", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .send({ report_date: "2026-04-18" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  // AT-DR-002 #1: 正常作成（下書き）
+  it("正常作成（下書き）: 訪問記録2件 → 201", async () => {
+    mockCustomerFindMany.mockResolvedValue([
+      { customerId: 10 },
+      { customerId: 15 },
+    ]);
+    const createdReport = makeReport({
+      status: "draft",
+      visitRecords: [
+        {
+          visitId: 1,
+          customer: { customerId: 10, companyName: "株式会社○○" },
+          visitContent: "初回提案",
+          visitOrder: 1,
+        },
+        {
+          visitId: 2,
+          customer: { customerId: 15, companyName: "株式会社△△" },
+          visitContent: "フォローアップ",
+          visitOrder: 2,
+        },
+      ],
+    });
+    mockDailyReportCreate.mockResolvedValue(createdReport);
+
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({
+        report_date: "2026-04-18",
+        visit_records: [
+          { customer_id: 10, visit_content: "初回提案", visit_order: 1 },
+          { customer_id: 15, visit_content: "フォローアップ", visit_order: 2 },
+        ],
+        status: "draft",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.report_id).toBe(1);
+    expect(res.body.data.status).toBe("draft");
+    expect(res.body.data.visit_records).toHaveLength(2);
+    expect(res.body.data.user).toEqual({ user_id: 1, name: "山田 太郎" });
+    expect(res.body.data.report_date).toBe("2026-04-18");
+  });
+
+  // AT-DR-002 #2: 正常作成（提出）
+  it("正常作成（提出）: status=submitted → 201, status=submitted で返る", async () => {
+    mockCustomerFindMany.mockResolvedValue([{ customerId: 10 }]);
+    const createdReport = makeReport({
+      status: "submitted",
+      visitRecords: [
+        {
+          visitId: 1,
+          customer: { customerId: 10, companyName: "株式会社○○" },
+          visitContent: "提案",
+          visitOrder: 1,
+        },
+      ],
+    });
+    mockDailyReportCreate.mockResolvedValue(createdReport);
+
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({
+        report_date: "2026-04-18",
+        visit_records: [{ customer_id: 10, visit_content: "提案", visit_order: 1 }],
+        status: "submitted",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe("submitted");
+  });
+
+  // AT-DR-002 #3: 訪問記録なしで作成
+  it("訪問記録なしで作成: 正常に作成される (201)", async () => {
+    const createdReport = makeReport({ visitRecords: [] });
+    mockDailyReportCreate.mockResolvedValue(createdReport);
+
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({
+        report_date: "2026-04-18",
+        visit_records: [],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.visit_records).toHaveLength(0);
+  });
+
+  // AT-DR-002 #4: 同日に2回作成 → 409
+  it("同日に2回作成: 409 CONFLICT", async () => {
+    mockDailyReportCreate.mockRejectedValue({ code: "P2002" });
+
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({ report_date: "2026-04-18" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("CONFLICT");
+  });
+
+  // バリデーション: report_date が未入力
+  it("report_date が未入力: 400 VALIDATION_ERROR", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // バリデーション: report_date が不正な形式
+  it("report_date が不正な形式: 400 VALIDATION_ERROR", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({ report_date: "20260418" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // UT-V-001 #4: visit_content が1001文字
+  it("visit_content が1001文字: 400 VALIDATION_ERROR", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({
+        report_date: "2026-04-18",
+        visit_records: [
+          { customer_id: 1, visit_content: "a".repeat(1001), visit_order: 1 },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // UT-V-001 #6: problem が2001文字
+  it("problem が2001文字: 400 VALIDATION_ERROR", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({ report_date: "2026-04-18", problem: "a".repeat(2001) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // UT-V-001 #7: plan が2001文字
+  it("plan が2001文字: 400 VALIDATION_ERROR", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({ report_date: "2026-04-18", plan: "a".repeat(2001) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // UT-V-001 #8: status が不正な値
+  it("status が不正な値: 400 VALIDATION_ERROR", async () => {
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({ report_date: "2026-04-18", status: "published" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // UT-V-001 #9: customer_id が存在しない
+  it("存在しない customer_id: 400 VALIDATION_ERROR", async () => {
+    mockCustomerFindMany.mockResolvedValue([]);
+
+    const res = await request(buildApp())
+      .post("/v1/daily-reports")
+      .set("Authorization", `Bearer ${salesToken}`)
+      .send({
+        report_date: "2026-04-18",
+        visit_records: [{ customer_id: 9999, visit_content: "テスト", visit_order: 1 }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import { errorHandler } from "./middlewares/errorHandler";
 import authRouter from "./routes/auth";
+import dailyReportsRouter from "./routes/dailyReports";
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;
@@ -24,6 +25,7 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/v1/auth", authRouter);
+app.use("/v1/daily-reports", dailyReportsRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/routes/dailyReports.ts
+++ b/backend/src/routes/dailyReports.ts
@@ -1,0 +1,254 @@
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { PrismaClient } from "@prisma/client";
+import { AppError } from "../middlewares/errorHandler";
+import { authenticate } from "../middlewares/auth";
+import { requireRole } from "../middlewares/role";
+
+const router = Router();
+const prisma = new PrismaClient();
+
+const getReportsQuerySchema = z.object({
+  user_id: z.coerce.number().int().positive().optional(),
+  date_from: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "date_fromはYYYY-MM-DD形式で入力してください" })
+    .optional(),
+  date_to: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "date_toはYYYY-MM-DD形式で入力してください" })
+    .optional(),
+  status: z.enum(["draft", "submitted"]).optional(),
+  page: z.coerce.number().int().positive().default(1),
+  per_page: z.coerce.number().int().positive().max(100).default(20),
+});
+
+// GET /v1/daily-reports
+router.get(
+  "/",
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const parsed = getReportsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      const details = parsed.error.issues.map((e) => ({
+        field: e.path.join("."),
+        message: e.message,
+      }));
+      return next(
+        new AppError(400, "VALIDATION_ERROR", "クエリパラメータが正しくありません", details)
+      );
+    }
+
+    const { user_id, date_from, date_to, status, page, per_page } = parsed.data;
+    const currentUser = req.user!;
+
+    type ReportWhere = {
+      userId?: number;
+      reportDate?: { gte?: Date; lte?: Date };
+      status?: "draft" | "submitted";
+    };
+
+    const where: ReportWhere = {};
+
+    if (currentUser.role === "sales") {
+      where.userId = currentUser.user_id;
+    } else if (user_id !== undefined) {
+      where.userId = user_id;
+    }
+
+    if (date_from !== undefined || date_to !== undefined) {
+      where.reportDate = {};
+      if (date_from !== undefined) where.reportDate.gte = new Date(date_from);
+      if (date_to !== undefined) where.reportDate.lte = new Date(date_to);
+    }
+
+    if (status !== undefined) {
+      where.status = status;
+    }
+
+    try {
+      const [total, items] = await Promise.all([
+        prisma.dailyReport.count({ where }),
+        prisma.dailyReport.findMany({
+          where,
+          skip: (page - 1) * per_page,
+          take: per_page,
+          orderBy: { reportDate: "desc" },
+          include: {
+            user: { select: { userId: true, name: true } },
+            visitRecords: { select: { visitId: true } },
+          },
+        }),
+      ]);
+
+      res.status(200).json({
+        data: {
+          items: items.map((r) => ({
+            report_id: r.reportId,
+            user: { user_id: r.user.userId, name: r.user.name },
+            report_date: r.reportDate.toISOString().slice(0, 10),
+            status: r.status,
+            visit_count: r.visitRecords.length,
+            created_at: r.createdAt.toISOString(),
+            updated_at: r.updatedAt.toISOString(),
+          })),
+          pagination: {
+            total,
+            page,
+            per_page,
+            total_pages: Math.ceil(total / per_page),
+          },
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+const visitRecordSchema = z.object({
+  customer_id: z.number().int().positive({ message: "customer_idは正の整数を指定してください" }),
+  visit_content: z
+    .string()
+    .min(1, { message: "訪問内容は必須です" })
+    .max(1000, { message: "訪問内容は1000文字以内で入力してください" }),
+  visit_order: z.number().int().positive({ message: "visit_orderは正の整数を指定してください" }),
+});
+
+const createReportSchema = z.object({
+  report_date: z
+    .string({ message: "report_dateは必須です" })
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "report_dateはYYYY-MM-DD形式で入力してください" }),
+  visit_records: z.array(visitRecordSchema).default([]),
+  problem: z
+    .string()
+    .max(2000, { message: "課題・相談は2000文字以内で入力してください" })
+    .optional(),
+  plan: z
+    .string()
+    .max(2000, { message: "明日やることは2000文字以内で入力してください" })
+    .optional(),
+  status: z.enum(["draft", "submitted"]).default("draft"),
+});
+
+// POST /v1/daily-reports
+router.post(
+  "/",
+  authenticate,
+  requireRole("sales"),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const parsed = createReportSchema.safeParse(req.body);
+    if (!parsed.success) {
+      const details = parsed.error.issues.map((e) => ({
+        field: e.path.join("."),
+        message: e.message,
+      }));
+      return next(
+        new AppError(400, "VALIDATION_ERROR", "入力値が正しくありません", details)
+      );
+    }
+
+    const { report_date, visit_records, problem, plan, status } = parsed.data;
+    const userId = req.user!.user_id;
+
+    if (visit_records.length > 0) {
+      const customerIds = visit_records.map((r) => r.customer_id);
+      let customers;
+      try {
+        customers = await prisma.customer.findMany({
+          where: { customerId: { in: customerIds } },
+          select: { customerId: true },
+        });
+      } catch (err) {
+        return next(err);
+      }
+      const foundIds = customers.map((c) => c.customerId);
+      const missingId = customerIds.find((id) => !foundIds.includes(id));
+      if (missingId !== undefined) {
+        return next(
+          new AppError(400, "VALIDATION_ERROR", "指定された顧客IDが存在しません", [
+            { field: "customer_id", message: `customer_id: ${missingId} は存在しません` },
+          ])
+        );
+      }
+    }
+
+    let report;
+    try {
+      report = await prisma.dailyReport.create({
+        data: {
+          userId,
+          reportDate: new Date(report_date),
+          problem: problem ?? null,
+          plan: plan ?? null,
+          status,
+          visitRecords: {
+            create: visit_records.map((r) => ({
+              customerId: r.customer_id,
+              visitContent: r.visit_content,
+              visitOrder: r.visit_order,
+            })),
+          },
+        },
+        include: {
+          user: { select: { userId: true, name: true } },
+          visitRecords: {
+            include: {
+              customer: { select: { customerId: true, companyName: true } },
+            },
+            orderBy: { visitOrder: "asc" },
+          },
+          comments: {
+            include: {
+              user: { select: { userId: true, name: true } },
+            },
+            orderBy: { createdAt: "asc" },
+          },
+        },
+      });
+    } catch (err: unknown) {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        (err as { code: string }).code === "P2002"
+      ) {
+        return next(
+          new AppError(409, "CONFLICT", "指定した日付の日報は既に存在します")
+        );
+      }
+      return next(err);
+    }
+
+    res.status(201).json({
+      data: {
+        report_id: report.reportId,
+        user: { user_id: report.user.userId, name: report.user.name },
+        report_date: report.reportDate.toISOString().slice(0, 10),
+        visit_records: report.visitRecords.map((v) => ({
+          visit_id: v.visitId,
+          customer: {
+            customer_id: v.customer.customerId,
+            company_name: v.customer.companyName,
+          },
+          visit_content: v.visitContent,
+          visit_order: v.visitOrder,
+        })),
+        problem: report.problem,
+        plan: report.plan,
+        status: report.status,
+        comments: report.comments.map((c) => ({
+          comment_id: c.commentId,
+          user: { user_id: c.user.userId, name: c.user.name },
+          body: c.body,
+          created_at: c.createdAt.toISOString(),
+        })),
+        created_at: report.createdAt.toISOString(),
+        updated_at: report.updatedAt.toISOString(),
+      },
+    });
+  }
+);
+
+export default router;


### PR DESCRIPTION
## Summary

- `GET /v1/daily-reports`: ロール別フィルタ（sales=自分のみ / manager=全員）・クエリパラメータ（user_id / date_from / date_to / status）・ページネーション対応
- `POST /v1/daily-reports`: salesロールのみ作成可・visit_records の顧客ID存在確認・同一 (user_id, report_date) 重複で 409・manager アクセスで 403

## 実装詳細

- `backend/src/routes/dailyReports.ts` — ルートハンドラー（Zod バリデーション・Prisma クエリ）
- `backend/src/index.ts` — `/v1/daily-reports` のルート登録
- `backend/src/__tests__/routes/dailyReports.test.ts` — 22 テストケース（テスト仕様書 AT-DR-001/002・UT-V-001 準拠）

## Test plan

- [x] `GET /daily-reports` ロール別フィルタ動作確認（AT-DR-001 #1〜4）
- [x] ページネーション動作確認（AT-DR-001 #7）
- [x] `POST /daily-reports` 下書き・提出作成（AT-DR-002 #1〜3）
- [x] 重複作成で 409（AT-DR-002 #4）
- [x] manager が作成すると 403（AT-DR-002 #5）
- [x] バリデーションエラー（UT-V-001 #4/6/7/8/9）
- [x] 全 40 テスト通過
- [x] TypeScript 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)